### PR TITLE
Updates newest_backup_date and oldest_backup_date

### DIFF
--- a/resources/lang/fr/notifications.php
+++ b/resources/lang/fr/notifications.php
@@ -40,6 +40,6 @@ return [
     'newest_backup_size' => 'Taille de sauvegarde la plus récente',
     'number_of_backups' => 'Nombre de sauvegardes',
     'total_storage_used' => 'Stockage total utilisé',
-    'newest_backup_date' => 'Taille de sauvegarde la plus récente',
-    'oldest_backup_date' => 'Taille de sauvegarde la plus ancienne',
+    'newest_backup_date' => 'Date de la sauvegarde la plus récente',
+    'oldest_backup_date' => 'Date de la sauvegarde la plus ancienne',
 ];


### PR DESCRIPTION
Updates newest_backup_date and oldest_backup_date keys in french translations to be date instead of size (Date instead of Taille).

Thanks for this nice package (and all others you maintain)!